### PR TITLE
Add deployed JupyterBook URL

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,15 @@
 
 *A quick summary of what’s changed or added.*
 
+# Deployed JupyterBook
+
+Please paste the URL of the deployed JupyterBook (GitHub Pages). This must be provided before requesting review.
+
+Deployed URL: https://
+
 # Checklist
 
 Before submitting, make sure:
 
 [ ] GitHub Pages [is turned on](https://github.com/ecmwf-training/jupyterbook-template?tab=readme-ov-file#13-enable-github-pages) in the repo settings.
+[ ] Deployed [JupyterBook URL](https://github.com/ecmwf-training/jupyterbook-template?tab=readme-ov-file#13-enable-github-pages) included above

--- a/.github/workflows/build-deploy-book.yaml
+++ b/.github/workflows/build-deploy-book.yaml
@@ -75,15 +75,3 @@ jobs:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4
-
-      - name: Add deployment URL to Job Summary
-        if: steps.deployment.outputs.page_url != ''
-        run: |
-          {
-            echo "## GitHub Pages Deployment";
-            echo "";
-            echo "Branch: \`${{ github.ref_name }}\`";
-            echo "Commit: \`${{ github.sha }}\`";
-            echo "";
-            echo "Jupyter Book deployed at: ${{ steps.deployment.outputs.page_url }}";
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-deploy-book.yaml
+++ b/.github/workflows/build-deploy-book.yaml
@@ -75,3 +75,15 @@ jobs:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Add deployment URL to Job Summary
+        if: steps.deployment.outputs.page_url != ''
+        run: |
+          {
+            echo "## GitHub Pages Deployment";
+            echo "";
+            echo "Branch: \`${{ github.ref_name }}\`";
+            echo "Commit: \`${{ github.sha }}\`";
+            echo "";
+            echo "Jupyter Book deployed at: ${{ steps.deployment.outputs.page_url }}";
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Go to the "Settings" tab, then navigate to "Pages" on the left-hand menu pane. I
 > <b>Public repository required for github pages</b> If you did not select "public" when creating the repository you will not be able to enable github pages (unless you are using github enterprise). To make the repository public go to "Settings" -> "General" -> "Danger Zone" -> "Change repository visibility"
 
 
-Now go to the "Actions" tab. You will see that the "Initial commit" action failed, this was because the pages were not enabled. You can then click the "Re-run all jobs" buttons in the top right to re-run the actions. This time it should succeed and provide a link to your github pages in the flow diagram.
+To get the link to the rendered Jupyter Book (github pages), go to the "Actions" tab. You will see that the "Initial commit" action failed, this was because the pages were not enabled. You can then click the "Re-run all jobs" buttons in the top right to re-run the actions. This time it should succeed and provide a link to your github pages in the flow diagram. Alternatively, you can find the link in the "Summary" section shown on the same page.
 
 > [!TIP]
 > <b>Optional</b> You can make this link easier to locate in the future by adding it to the "About" section in the right hand panel of the "Code" tab. Click on the settings cog next to about and check the "Use your GitHub Pages website" checkbox.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Go to the "Settings" tab, then navigate to "Pages" on the left-hand menu pane. I
 > <b>Public repository required for github pages</b> If you did not select "public" when creating the repository you will not be able to enable github pages (unless you are using github enterprise). To make the repository public go to "Settings" -> "General" -> "Danger Zone" -> "Change repository visibility"
 
 
-To get the link to the rendered Jupyter Book (github pages), go to the "Actions" tab. You will see that the "Initial commit" action failed, this was because the pages were not enabled. You can then click the "Re-run all jobs" buttons in the top right to re-run the actions. This time it should succeed and provide a link to your github pages in the flow diagram. Alternatively, you can find the link in the "Summary" section shown on the same page.
+To get the link to the rendered Jupyter Book (github pages), go to the "Actions" tab. You will see that the "Initial commit" action failed, this was because the pages were not enabled. You can then click the "Re-run all jobs" buttons in the top right to re-run the actions. This time it should succeed and provide a link to your github pages in the flow diagram.
 
 > [!TIP]
 > <b>Optional</b> You can make this link easier to locate in the future by adding it to the "About" section in the right hand panel of the "Code" tab. Click on the settings cog next to about and check the "Use your GitHub Pages website" checkbox.


### PR DESCRIPTION
This PR adds an new checklist item to ensure authors include the URL to the deployed JupyterBook, making it easier for reviewers to access it directly.

I also updated the README to guide authors on how to find and include this URL in their PRs.
