### PR TITLE
Add self-review checklist to review-book how-to

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,9 +8,36 @@ Please paste the URL of the deployed JupyterBook (GitHub Pages). This must be pr
 
 Deployed URL: https://
 
+# Manual-review self-check
+
+Before requesting review, complete the [self-review checklist](content/howto/review-book.md). Tick each item that has been addressed. For optional items that do not apply, write `N/A` with a brief comment.
+
+| Item | Checked: Yes or N/A | Comment (if any) |
+|---|---|---|
+| Notebook title and introduction |  |  |
+| Learning objectives |  |  |
+| &nbsp;&nbsp;- Target audience (optional) |  |  |
+| Prepare your environment |  |  |
+| &nbsp;&nbsp;- Special prerequisites (optional) |  |  |
+| &nbsp;&nbsp;- (Install and) Import libraries |  |  |
+| &nbsp;&nbsp;- Setup credentials (optional) |  |  |
+| &nbsp;&nbsp;- Define your data request (optional) |  |  |
+| Main workflow |  |  |
+| &nbsp;&nbsp;- Code sections |  |  |
+| Take home messages |  |  |
+| References |  |  |
+| Glossary (optional) |  |  |
+| Licence (optional / if applicable) |  |  |
+| Method and data choice |  |  |
+| Transferability |  |  |
+| Validation / limitations |  |  |
+| Figures and visualisations |  |  |
+| Code clarity |  |  |
+
 # Checklist
 
 Before submitting, make sure:
 
 - [ ] GitHub Pages [is turned on](content/howto/review-book.md) in the repo settings.
 - [ ] Deployed Jupyter Book URL is included above
+- [ ] Manual-review self-check is completed above, with `N/A` used where a criterion is not applicable.

--- a/content/howto/review-book.md
+++ b/content/howto/review-book.md
@@ -39,3 +39,21 @@ To get the link to the rendered Jupyter Book (GitHub pages), go to the "Actions"
 **Optional** You can make this link easier to locate in the future by adding it to the "About" section in the right hand panel of the "Code" tab. Click on the settings cog next to about and check the "Use your GitHub Pages website" checkbox.
 :::
 
+
+## Self-review checklist
+
+Before opening a pull request for review, verify that your notebook has filled in (or, where applicable, removed) each of the sections introduced by the template. The checklist below mirrors the manual-review criteria; the [pull request template](../../.github/pull_request_template.md) asks you to link to the section in your deployed book that satisfies each one.
+
+- **Prerequisites** — prior knowledge, related notebooks, required tools/accounts.
+- **Target audience** — skill level, role, domain background assumed.
+- **Introduction & workflow overview** — context plus an ordered outline of the steps.
+- **Learning objectives** — what the reader will be able to do after the notebook.
+- **Method and data justification** — why this method, why this dataset, assumptions and limits.
+- **Transferability** — what the learner can adapt (region, resolution, variables) and what is fixed.
+- **Validation** *(optional)* — sanity checks performed and known limitations.
+- **References** — datasets (DOI / persistent ID / stable URL), publications, reused figures.
+- **Definitions** *(optional)* — used only when several novel terms are introduced; otherwise define on first use.
+- **Figures** — title, axis labels with units, legend, caption with source/attribution; honest scaling; sufficient image quality.
+- **Code** — inline comments on non-trivial blocks; docstrings on custom functions; a markdown cell precedes each logical code block.
+
+If a section does not apply to your notebook, remove it (or mark it *not applicable*) rather than leaving the placeholder text in place.

--- a/content/howto/review-book.md
+++ b/content/howto/review-book.md
@@ -42,18 +42,29 @@ To get the link to the rendered Jupyter Book (GitHub pages), go to the "Actions"
 
 ## Self-review checklist
 
-Before opening a pull request for review, verify that your notebook has filled in (or, where applicable, removed) each of the sections introduced by the template. The checklist below mirrors the manual-review criteria; the [pull request template](../../.github/pull_request_template.md) asks you to link to the section in your deployed book that satisfies each one.
+Before opening a pull request for review, verify that your notebook has filled in (or, where applicable, removed) each of the sections introduced by the template. The checklist below mirrors the manual-review criteria; the [pull request template](../../.github/pull_request_template.md) asks you to demonstrate that each criterion has been addressed. Where applicable, provide a link to the relevant section in the deployed notebook.
 
-- **Prerequisites** — prior knowledge, related notebooks, required tools/accounts.
-- **Target audience** — skill level, role, domain background assumed.
-- **Introduction & workflow overview** — context plus an ordered outline of the steps.
+- **Notebook title and introduction** — title, context, purpose, and an ordered outline of the workflow.
 - **Learning objectives** — what the reader will be able to do after the notebook.
-- **Method and data justification** — why this method, why this dataset, assumptions and limits.
-- **Transferability** — what the learner can adapt (region, resolution, variables) and what is fixed.
-- **Validation** *(optional)* — sanity checks performed and known limitations.
-- **References** — datasets (DOI / persistent ID / stable URL), publications, reused figures.
-- **Definitions** *(optional)* — used only when several novel terms are introduced; otherwise define on first use.
-- **Figures** — title, axis labels with units, legend, caption with source/attribution; honest scaling; sufficient image quality.
-- **Code** — inline comments on non-trivial blocks; docstrings on custom functions; a markdown cell precedes each logical code block.
+  - **Target audience** *(optional)* — skill level, role, or domain background assumed.
+- **Prepare your environment** — short explanation of the setup steps needed before analysis.
+  - **Special prerequisites** *(optional)* — unusual tools, accounts, data access, or setup requirements.
+  - **(Install and) Import libraries** — required libraries are installed or imported clearly, with no unused or unexplained setup.
+  - **Setup credentials** *(optional)* — credentials are configured without exposing secrets.
+  - **Define your data request** *(optional)* — data request parameters are clear, reproducible, and appropriate for the notebook.
+- **Main workflow** — the analytical workflow is ordered and easy to follow.
+  - **Code sections** — generic placeholders such as `Code section 1` and `Code section 2` have been replaced with meaningful headings; each logical code block is preceded by explanatory markdown.
+- **Take home messages** — the notebook closes with the main learning points or practical conclusions.
+- **References** — datasets (DOI / persistent ID / stable URL), publications, and reused figures.
+- **Glossary** *(optional)* — used only when several novel terms are introduced; otherwise define terms on first use.
+- **Licence** *(optional / if applicable)* — licence terms are included where required for data, code, or reused material.
+
+Some manual-review criteria are notebook-wide checks rather than direct notebook sections. Use the pull request template to justify these items when they are not explicit in the notebook text:
+
+- **Method and data choice** — why the selected method and dataset are appropriate for the learning objective.
+- **Transferability** — what the learner can safely adapt (for example, region, resolution, variables, or time period) and what is fixed.
+- **Validation / limitations** — sanity checks performed, known limitations, or why a separate validation step is not applicable.
+- **Figures and visualisations** — titles, axis labels with units, legends, captions, source attribution, readable scaling, and sufficient image quality.
+- **Code clarity** — comments on non-trivial blocks, docstrings on custom functions, and readable cell length.
 
 If a section does not apply to your notebook, remove it (or mark it *not applicable*) rather than leaving the placeholder text in place.


### PR DESCRIPTION
\## Summary



Add a `## Self-review checklist` at the end of `review-book.md` that mirrors the manual-review-aligned sections of the template notebook. Authors verify each item before opening a pull request, so the manual reviewer's first action becomes "spot-check the boxes" rather than "discover the gaps".



The checklist cross-links to the new pull-request template (PR #4) and lists the sections introduced in PR #1 (notebook): Prerequisites, Target audience, Workflow overview, Learning objectives, Method and data justification, Transferability, Validation, References, Definitions, Figures, Code annotation.



\### Checklist criteria addressed



Cumulative reinforcement of the criteria addressed by PR #1 (template-notebook.ipynb) and PR #2 (best-practices.md)

